### PR TITLE
Add middleware support for path annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.0] - 2022-009-13
+## [0.3.1] - 2022-10-01
+### Added
+- Support for middlware in the @Path annotation when working with controllers.
+
+## [0.3.0] - 2022-09-13
 ### Changed
 - The Form API has changed a small bit. This is a breaking change. Overriding the validator function is the preferred way forward instead of passing it via constructor.
 

--- a/doc/site/docs/controllers/how_to_use_controllers.md
+++ b/doc/site/docs/controllers/how_to_use_controllers.md
@@ -54,6 +54,50 @@ class SampleController extends Controller {
 
 This assumes that you have a middleware named `userHasAccessMiddleware` in scope of this file. You'll want to substitute the name of your own middleware instead of using that one.
 
+## The Path Annotation
+
+The Path annotation can be applied to a class that extends `Controller` and allows you to set up the "root" path for that controller. Let's add a path annotation to the previous example:
+
+```dart
+@Path('/sample')
+class SampleController extends Controller {
+  @Injectable('UserService')
+  late UserService userService;
+  
+  @Get('/version')
+  version(_) => 'v1.0';
+
+  @Get('/show', [userHasAccessMiddleware])
+  Response show(Request request) => view('main_template');
+  
+  @Get('/users', [userHasAccessMiddleware])
+  Response users => UserService.getUsers();
+}
+```
+
+If the server were running on localhost:1234, mounting this controller into the router would create the following routes:
+- localhost:1234/sample/version
+- localhost:1234/sample/show
+- localhost:1234/sample/users
+
+Additionally, middleware can be added to the Path parameter, too. This is effectively the same thing as applying the middleware individually to _all_ of the routes under that path. For example, we can add the `userHasAccessMiddleware` to the `@Path` declaration, but it would also apply to the `@Get('/version')` declaration, too. A common example of when you may use this is to add controller-level middleware such as a controller specific logger or guarding access to all controller properties if a user is not logged in.
+
+```dart
+@Path('/sample', [userHasAccessMiddleware])
+class SampleController extends Controller {
+  @Injectable('UserService')
+  late UserService userService;
+  
+  @Get('/version')
+  version(_) => 'v1.0';
+
+  @Get('/show')
+  Response show(Request request) => view('main_template');
+  
+  @Get('/users')
+  Response users => UserService.getUsers();
+}
+```
 
 ## The View function
 


### PR DESCRIPTION
Add in support for Middleware in Path Annotations. This follows the existing guidelines for Middleware in HTTP Verb annotations.

Additionally, these middlewares apply before the HTTP verb middlewares and apply from left to right, just like the HTTP verb middlewares.