### PR TITLE
feat(context): establish steward context

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Here's an example of how you can use Steward!
 import 'package:steward/steward.dart';
 
 Future main() async {
-  var router = Router();
-  var container = CacheContainer();
+  final router = Router();
+  final container = Container();
   
   // Setup a DI binding for UserService
   container.bind('UserService', (_) => UserService());
@@ -51,14 +51,14 @@ Future main() async {
   });
   
   // Plucking things out of the container example
-  router.get('/config', (Request request) {
-    print(request.container.make('@config.app.name'));
-    return Response.Ok(request.container.make('@config.app.name'));
+  router.get('/config', (Context context) {
+    print(context.make('@config.app.name'));
+    return Response.Ok(context.make('@config.app.name'));
   });
   
   // Path Params example
-  router.get('/:name', (Request request) {
-    return Response.Ok(request.pathParams['name']);
+  router.get('/:name', (Context context) {
+    return Response.Ok(context.request.pathParams['name']);
   });
   
   var app = App(router: router);

--- a/bin/doctor.dart
+++ b/bin/doctor.dart
@@ -12,12 +12,12 @@ class DoctorCommand extends Command {
 
   @override
   void run(List<String> args, Map<String, dynamic> flags) {
-    var configExists = File('./config.yml').existsSync();
-    var viewsExist = Directory('./views').existsSync();
-    var pubspec = File('./pubspec.yaml');
-    var pubspecExists = pubspec.existsSync();
-    var pubspecContents = pubspecExists ? pubspec.readAsLinesSync() : [];
-    var stewardVersion = pubspecContents.firstWhere(
+    final configExists = File('./config.yml').existsSync();
+    final viewsExist = Directory('./views').existsSync();
+    final pubspec = File('./pubspec.yaml');
+    final pubspecExists = pubspec.existsSync();
+    final pubspecContents = pubspecExists ? pubspec.readAsLinesSync() : [];
+    final stewardVersion = pubspecContents.firstWhere(
         (element) => element.contains('steward:'),
         orElse: () => 'NOT FOUND');
 

--- a/bin/new.dart
+++ b/bin/new.dart
@@ -4,13 +4,13 @@ import 'package:bosun/bosun.dart';
 import 'new_middleware.dart';
 import 'new_view.dart';
 
-var configTemplate = '''---
+const configTemplate = '''---
 app:
   name: My Steward App
   port: 4040
 ''';
 
-var viewTemplate = '''<!DOCTYPE html>
+const viewTemplate = '''<!DOCTYPE html>
 <html lang="en">
 
 <head>
@@ -77,11 +77,11 @@ var viewTemplate = '''<!DOCTYPE html>
 </html>
 ''';
 
-var appTemplate = '''
+const appTemplate = '''
 import 'package:steward/steward.dart';
 
 Future main() async {
-  var router = Router();
+  final router = Router();
   router.get('/hello', (Context context) async {
     return Response.Ok('Hello World!');
   });
@@ -97,7 +97,7 @@ Future main() async {
 
 
   // Add your own DI objects to the container here
-  var app = App(router: router);
+  final app = App(router: router);
 
   return app.start();
 
@@ -114,11 +114,11 @@ class NewCommand extends Command {
 
   @override
   void run(List<String> args, Map<String, dynamic> flags) {
-    var name = args[0];
+    final name = args[0];
 
     Process.runSync('dart', ['create', name, '--template', 'console-full']);
 
-    var config = File('./$name/config.yml');
+    final config = File('./$name/config.yml');
     config.writeAsStringSync(configTemplate);
     Directory('./$name/views').createSync();
     Directory('./$name/assets').createSync();

--- a/bin/new.dart
+++ b/bin/new.dart
@@ -82,17 +82,17 @@ import 'package:steward/steward.dart';
 
 Future main() async {
   var router = Router();
-  router.get('/hello', (Request request) async {
+  router.get('/hello', (Context context) async {
     return Response.Ok('Hello World!');
   });
 
-  router.get('/config', (Request request) async {
-    print(request.container.make('@config.app.name'));
-    return Response.Ok(request.container.make('@config.app.name'));
+  router.get('/config', (Context context) async {
+    print(context.read('@config.app.name'));
+    return Response.Ok(context.read('@config.app.name'));
   });
 
-  router.get('/:name', (Request request) async {
-    return Response.Ok(request.pathParams['name']);
+  router.get('/:name', (Context context) async {
+    return Response.Ok(context.request.pathParams['name']);
   });
 
 

--- a/bin/new_middleware.dart
+++ b/bin/new_middleware.dart
@@ -5,13 +5,13 @@ import 'package:recase/recase.dart';
 
 var middlwareTemplate = '''import 'package:steward/steward.dart';
 
-Future<Response> Function(Request) {{{name}}}Middleware(
-    Future<Response> Function(Request) next) {
-  return (Request request) {
+Future<Response> Function(Context) {{{name}}}Middleware(
+    Future<Response> Function(Context) next) {
+  return (Context context) {
 
     // Do something here!
     
-    return next(request);
+    return next(context);
   };
 }
 ''';

--- a/bin/new_middleware.dart
+++ b/bin/new_middleware.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:bosun/bosun.dart';
 import 'package:recase/recase.dart';
 
-var middlwareTemplate = '''import 'package:steward/steward.dart';
+const middlwareTemplate = '''import 'package:steward/steward.dart';
 
 Future<Response> Function(Context) {{{name}}}Middleware(
     Future<Response> Function(Context) next) {
@@ -25,7 +25,7 @@ class NewMiddlewareCommand extends Command {
 
   @override
   void run(List<String> args, Map<String, dynamic> flags) {
-    var name = args[0];
+    final name = args[0];
     // write initial files
     final middleware = Directory('./lib/middleware');
     if (!middleware.existsSync()) {

--- a/bin/new_view.dart
+++ b/bin/new_view.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:bosun/bosun.dart';
 import 'package:recase/recase.dart';
 
-var viewTemplate = '''<!DOCTYPE html>
+const viewTemplate = '''<!DOCTYPE html>
 <html lang="en">
 
 <head>
@@ -75,7 +75,7 @@ class NewViewCommand extends Command {
 
   @override
   void run(List<String> args, Map<String, dynamic> flags) {
-    var name = args[0];
+    final name = args[0];
     // write initial files
     final views = Directory('./lib/views');
     if (!views.existsSync()) {

--- a/doc/site/docs/container/what_is_a_container.md
+++ b/doc/site/docs/container/what_is_a_container.md
@@ -15,7 +15,7 @@ The intent behind DI is to provide a separation of concerns when it comes to con
 Let's start by binding a "Service" to the DI container.
 
 ```dart
-var container = CacheContainer();
+final container = Container();
 container.bind<String>('sample', (Container container) {
   return 'ABC123';
 });
@@ -28,7 +28,7 @@ This simple snippet shows how we can new up an implementer of Container (CacheCo
 Let's bind the same value from above:
 
 ```dart
-var container = CacheContainer();
+final container = StewardContainer();
 container.bind<String>('sample', (Container container) {
   return 'ABC123';
 });
@@ -37,7 +37,7 @@ container.bind<String>('sample', (Container container) {
 Now we'll likely want to retrieve this String from our container at some point. Doing so is fairly simple!
 
 ```dart
-var key = container.make<String>('sample');
+final key = container.make<String>('sample');
 // key is now 'ABC123'
 ```
 
@@ -53,7 +53,7 @@ class UserService {
 }
 
 
-var container = CacheContainer();
+final container = StewardContainer();
 container.bind<UserService>(UserService.Key, (Container container) {
   return UserService('1');
 });

--- a/doc/site/docs/router/middleware.md
+++ b/doc/site/docs/router/middleware.md
@@ -19,7 +19,7 @@ While this may look complex, the actual implementation of a custom middleware is
 Future<Response> Function(Request) RequestLogger(
     Future<Response> Function(Request) next) {
   return (Request request) {
-    print('Incoming Request: ${request.request.uri}');
+    print('Incoming Request: ${request.uri}');
     return next(request);
   };
 }

--- a/doc/site/docs/router/routers.md
+++ b/doc/site/docs/router/routers.md
@@ -27,7 +27,7 @@ The 2nd parameter to each of the Router methods is the handler. The Handler is a
 import 'package:steward/steward.dart';
 
 Future main() async {
-  var router = Router();
+  final router = Router();
   router.get('/hello', (Request request) async {
     return Response.Ok("Hello World!");
   });

--- a/example/main.dart
+++ b/example/main.dart
@@ -5,18 +5,17 @@ Future main() async {
   var router = Router();
 
   router.staticFiles('/assets');
-  router.get('/hello', (Request request) async {
+  router.get('/hello', (Context context) async {
     return Response.Ok('Hello World!');
   });
 
-  router.get('/config', (Request request) async {
-    print(request.container);
-    print(request.container.make('@config'));
-    return Response.Ok(request.container.make('@config'));
+  router.get('/config', (Context context) async {
+    print(context.read('@config'));
+    return Response.Ok(context.read('@config'));
   });
 
-  router.get('/:name', (Request request) async {
-    return Response.Ok(request.pathParams['name']);
+  router.get('/:name', (Context context) async {
+    return Response.Ok(context.request.pathParams['name']);
   });
 
   var app = App(router: router);

--- a/example/main.dart
+++ b/example/main.dart
@@ -2,7 +2,7 @@ import 'package:steward/app/app.dart';
 import 'package:steward/router/router.dart';
 
 Future main() async {
-  var router = Router();
+  final router = Router();
 
   router.staticFiles('/assets');
   router.get('/hello', (Context context) async {
@@ -18,7 +18,7 @@ Future main() async {
     return Response.Ok(context.request.pathParams['name']);
   });
 
-  var app = App(router: router);
+  final app = App(router: router);
 
   return app.start();
 }

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -40,10 +40,10 @@ class App {
   /// and ultimately preprends "@config." to the key before adding that
   /// config item to the DI container.
   void _loadConfigIntoContainer() {
-    var configFile = File('config.yml');
-    var configReader = ConfigReader(file: configFile)..read();
-    var config = configReader.parsed;
-    var flat = flatten(config);
+    final configFile = File('config.yml');
+    final configReader = ConfigReader(file: configFile)..read();
+    final config = configReader.parsed;
+    final flat = flatten(config);
     flat.entries.forEach((element) {
       _container.bind('@config.' + element.key, (_) => element.value);
     });
@@ -51,14 +51,14 @@ class App {
 
   void _loadViewsIntoContainer() {
     try {
-      var files = Directory('./views')
+      final files = Directory('./views')
           .listSync(recursive: true, followLinks: true)
           .whereType<File>()
           .where((file) => file.path.endsWith('.mustache'))
           .map((file) =>
               {'path': file.path, 'contents': file.readAsStringSync()});
       files.forEach((file) {
-        var key = file['path']
+        final key = file['path']
             ?.replaceAll('/', '.')
             .replaceFirst('..views.', '')
             .replaceFirst('.mustache', '');

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -12,7 +12,7 @@ enum Environment { production, other }
 class App {
   Router router;
   Environment environment;
-  late Container _container;
+  late StewardContainer _container;
 
   App({required this.router, this.environment = Environment.other}) {
     _container = router.container;

--- a/lib/config/config_reader.dart
+++ b/lib/config/config_reader.dart
@@ -12,7 +12,7 @@ class ConfigReader {
 
   /// Reads the config file and parses it into a Map.
   void read() {
-    var data = file.readAsStringSync();
+    final data = file.readAsStringSync();
     YamlMap yamlMap = loadYaml(data);
     // hacky way to go from yaml map to normal map
     parsed = jsonDecode(jsonEncode(yamlMap));

--- a/lib/forms/forms.dart
+++ b/lib/forms/forms.dart
@@ -22,7 +22,7 @@ abstract class Form {
   /// Returns a list of form errors, or an empty list if there are no errors - in which case isValid will be true.
   /// Validation is handled lazily so you'll need to call this function to trigger validation.
   List<FormError> validate() {
-    var errors = validator();
+    final errors = validator();
 
     if (errors.isNotEmpty) {
       _isValid = false;

--- a/lib/middleware/cors_middleware.dart
+++ b/lib/middleware/cors_middleware.dart
@@ -11,7 +11,7 @@ MiddlewareFunc CorsMiddleware(
     List<String>? allowHeaders}) {
   return (Future<Response> Function(Context) next) {
     return (Context context) async {
-      var resp = await next(context);
+      final resp = await next(context);
 
       if (allowOrigin != null) {
         resp.headers.add(_originKey, allowOrigin);

--- a/lib/middleware/cors_middleware.dart
+++ b/lib/middleware/cors_middleware.dart
@@ -9,9 +9,9 @@ MiddlewareFunc CorsMiddleware(
     {List<String>? allowOrigin,
     List<String>? allowMethods,
     List<String>? allowHeaders}) {
-  return (Future<Response> Function(Request) next) {
-    return (Request request) async {
-      var resp = await next(request);
+  return (Future<Response> Function(Context) next) {
+    return (Context context) async {
+      var resp = await next(context);
 
       if (allowOrigin != null) {
         resp.headers.add(_originKey, allowOrigin);

--- a/lib/middleware/middleware.dart
+++ b/lib/middleware/middleware.dart
@@ -1,5 +1,4 @@
-import 'package:steward/router/request.dart';
-import 'package:steward/router/response.dart';
+import 'package:steward/router/router.dart';
 
 /// MiddlewareFunc is a typedef that describes what a middleware function looks like.
 /// The main takeaway here is that this function takes in the next handler in the chain
@@ -7,5 +6,5 @@ import 'package:steward/router/response.dart';
 /// This might sound confusing, but the implementation for this middleware pattern
 /// is likely not as bad as you may think! Check out the documentation for more
 /// information.
-typedef MiddlewareFunc = Future<Response> Function(Request) Function(
-    Future<Response> Function(Request) nextHandler);
+typedef MiddlewareFunc = Future<Response> Function(Context) Function(
+    Future<Response> Function(Context) nextHandler);

--- a/lib/middleware/request_logger.dart
+++ b/lib/middleware/request_logger.dart
@@ -6,7 +6,7 @@ import 'package:steward/router/response.dart';
 Future<Response> Function(Request) RequestLogger(
     Future<Response> Function(Request) next) {
   return (Request request) {
-    print('Incoming Request: ${request.request.uri}');
+    print('Incoming Request: ${request.uri}');
     return next(request);
   };
 }

--- a/lib/router/README.md
+++ b/lib/router/README.md
@@ -15,7 +15,7 @@ import 'package:steward/router/response.dart';
 import 'package:steward/router/request.dart';
 
 Future main() async {
-  var router = Router();
+  final router = Router();
   router.get('/hello', (Request request) {
     return Response.Ok("Hello World!");
   });

--- a/lib/router/context.dart
+++ b/lib/router/context.dart
@@ -1,0 +1,27 @@
+import 'package:steward/container/container.dart';
+import 'package:steward/router/router.dart';
+
+abstract interface class Context implements Cloneable, ContainerReable {
+  Request get request;
+}
+
+class StewardContext implements Context {
+  final StewardContainer _container;
+  final Request _request;
+
+  StewardContext({StewardContainer? container, required Request request})
+      : _container = container ?? StewardContainer(),
+        _request = request;
+
+  @override
+  StewardContext clone() {
+    // TODO: implement clone
+    throw UnimplementedError();
+  }
+
+  @override
+  Request get request => _request;
+
+  @override
+  T? read<T>(String key) => _container.read<T>(key);
+}

--- a/lib/router/request.dart
+++ b/lib/router/request.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 import 'dart:io';
-import 'package:steward/container/container.dart';
 
 /// Request models the request object that Steward processes.
 /// It is a wrapper around the [HttpRequest] object but this may change in future iterations.
@@ -8,21 +7,9 @@ import 'package:steward/container/container.dart';
 /// when working with middleware and/or intercepting incoming requests.
 class Request {
   HttpRequest request;
-  Container container = CacheContainer();
   Map<String, dynamic> pathParams;
 
   Request({required this.request, this.pathParams = const {}});
-
-  /// Sets the container for this request
-  /// This is useful for passing data between middleware and the controller
-  /// but is also necessary as Steward expects the container to be present.
-  /// If you new up a request manually, you will almost certainly want to
-  /// set the container yourself.
-  void setContainer(Container? container) {
-    if (container != null) {
-      this.container = container;
-    }
-  }
 
   /// Returns the body of this request as a Future<String>.
   Future<String> getBody() {
@@ -37,4 +24,7 @@ class Request {
 
   /// Gets the HTTPSession associated with this request
   HttpSession get session => request.session;
+
+  /// Gets the URI of the request
+  Uri get uri => request.uri;
 }

--- a/lib/router/response.dart
+++ b/lib/router/response.dart
@@ -100,7 +100,7 @@ class Response {
   Response.View(String templateString,
       {this.statusCode = HttpStatus.ok,
       Map<String, dynamic> varMap = const {}}) {
-    var template = Template(templateString);
+    final template = Template(templateString);
     body = template.renderString(varMap);
   }
 
@@ -116,8 +116,8 @@ class Response {
 /// contents of the steward response to the HTTP response.
 /// TODO: this should only be called by Steward
 Future<void> writeResponse(HttpRequest request, Future<Response> resp) async {
-  var response = await resp;
-  var body = response.body;
+  final response = await resp;
+  final body = response.body;
 
   request.response.headers.contentType = response.headers.contentType;
   request.response.headers.date = response.headers.date;

--- a/lib/router/router.dart
+++ b/lib/router/router.dart
@@ -113,7 +113,7 @@ class Router {
   }
 
   Future serveHTTP() async {
-    var port = container.read('@config.app.port') ?? 4040;
+    final port = container.read('@config.app.port') ?? 4040;
     server = await HttpServer.bind(
       InternetAddress.anyIPv6,
       port,
@@ -124,10 +124,10 @@ class Router {
     await for (HttpRequest request in server!) {
       var hasMatch = false;
       for (var i = 0; i < bindings.length; i++) {
-        var params = <String>[];
+        final params = <String>[];
 
 // Get the root pattern from the pathToRegex call
-        var rootPattern = pathToRegExp(bindings[i].path,
+        final rootPattern = pathToRegExp(bindings[i].path,
                 parameters: params, prefix: bindings[i].isPrefixBinding)
             .pattern;
 
@@ -142,15 +142,15 @@ class Router {
           cleanedPattern =
               cleanedPattern.substring(0, cleanedPattern.length - 1);
         }
-        var regex = RegExp(
+        final regex = RegExp(
             '$cleanedPattern\\/?${bindings[i].isPrefixBinding ? '\$)' : '\$'}',
             caseSensitive: false);
         hasMatch = regex.hasMatch(request.uri.path);
 
         if (hasMatch) {
-          var match = regex.matchAsPrefix(request.uri.path);
+          final match = regex.matchAsPrefix(request.uri.path);
           if (match != null) {
-            var pathParams = extract(params, match);
+            final pathParams = extract(params, match);
 
             final ctx = StewardContext(
                 request: Request(request: request, pathParams: pathParams),
@@ -194,7 +194,7 @@ class Router {
         handler = element(handler);
       });
 
-      var response = handler(context);
+      final response = handler(context);
       await writeResponse(request, response);
     } catch (err, stacktrace) {
       await writeErrorResponse(request, err, stacktrace);

--- a/lib/router/static_binding.dart
+++ b/lib/router/static_binding.dart
@@ -10,8 +10,8 @@ class StaticBinding extends RouteBinding {
   static final textExtensions = ['css', 'csv', 'html', 'xml'];
 
   @override
-  Future<Response> process(Request request) async {
-    var assetPath = '$path${request.request.uri.path.split(path).last}';
+  Future<Response> process(Context context) async {
+    var assetPath = '$path${context.request.uri.path.split(path).last}';
     var assetType = 'text/html';
 
     try {

--- a/lib/steward.dart
+++ b/lib/steward.dart
@@ -1,7 +1,7 @@
 export 'router/router.dart';
 export 'router/response.dart';
 export 'router/request.dart';
-export 'container/container.dart' show Container, Injectable, CacheContainer;
+export 'container/container.dart' show Container, StewardContainer;
 export 'forms/forms.dart' show Form, FormError;
 export 'middleware/middleware.dart';
 export 'app/app.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -498,4 +498,4 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
+  dart: ">=3.1.0 <4.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -498,4 +498,4 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0 <4.0.0"
+  dart: ">=3.0.0 <4.0.0"

--- a/test/app/app_test.dart
+++ b/test/app/app_test.dart
@@ -4,7 +4,7 @@ import 'package:mockito/mockito.dart';
 
 class MockRouter extends Fake implements Router {
   @override
-  final Container container;
+  final StewardContainer container;
 
   MockRouter({required this.container});
 
@@ -17,7 +17,7 @@ class MockRouter extends Fake implements Router {
 void main() {
   group('App', () {
     test('throws exception if cant find config.yml', () async {
-      final container = CacheContainer();
+      final container = StewardContainer();
       final mockRouter = MockRouter(container: container);
       final app = App(router: mockRouter);
 
@@ -25,14 +25,14 @@ void main() {
     });
 
     test('binds the environment into the application', () async {
-      final container = CacheContainer();
+      final container = StewardContainer();
       final mockRouter = MockRouter(container: container);
       try {
         // this blows up because the config file is missing
         final app = App(router: mockRouter);
         await app.start();
       } catch (_) {}
-      expect(container.make<Environment>('@environment'), Environment.other);
+      expect(container.read<Environment>('@environment'), Environment.other);
     });
   });
 }

--- a/test/container/container_test.dart
+++ b/test/container/container_test.dart
@@ -4,54 +4,54 @@ import 'package:steward/steward.dart';
 void main() {
   group('Container tests', () {
     test('should bind and resolve properly', () {
-      var container = CacheContainer();
-      container.bind<String>('key', (Container container) {
+      var container = StewardContainer();
+      container.bind<String>('key', (container) {
         return 'ABC123';
       });
 
-      var key = container.make<String>('key');
+      var key = container.read<String>('key');
       expect(key, 'ABC123');
     });
 
     test(
         'container items should be able to be built with other container items',
         () {
-      var container = CacheContainer();
-      container.bind<String>('key', (Container container) {
+      var container = StewardContainer();
+      container.bind<String>('key', (container) {
         return 'ABC';
       });
 
-      container.bind<String>('full_key', (Container container) {
-        return container.make<String>('key')! + '123';
+      container.bind<String>('full_key', (container) {
+        return container.read<String>('key')! + '123';
       });
 
-      expect(container.make<String>('full_key'), 'ABC123');
+      expect(container.read<String>('full_key'), 'ABC123');
     });
 
     test('should return null when an unbound binding is made', () {
-      var container = CacheContainer();
-      expect(container.make('key'), null);
+      var container = StewardContainer();
+      expect(container.read('key'), null);
     });
   });
 
   group('clone', () {
     test('Clones should have access to the bindings declare before cloning',
         () {
-      var container = CacheContainer();
+      var container = StewardContainer();
       container.bind('foo', (p0) => 'bar');
 
       var container2 = container.clone();
-      expect(container2.make('foo'), equals('bar'));
+      expect(container2.read('foo'), equals('bar'));
     });
 
     test(
         'updating a binding in a clone should not update the binding for the root',
         () {
-      var container = CacheContainer();
+      var container = StewardContainer();
       var container2 = container.clone();
 
       container2.bind('foo', (p0) => 'bar');
-      expect(container.make('foo'), equals(null));
+      expect(container.read('foo'), equals(null));
     });
   });
 }

--- a/test/container/container_test.dart
+++ b/test/container/container_test.dart
@@ -4,19 +4,19 @@ import 'package:steward/steward.dart';
 void main() {
   group('Container tests', () {
     test('should bind and resolve properly', () {
-      var container = StewardContainer();
+      final container = StewardContainer();
       container.bind<String>('key', (container) {
         return 'ABC123';
       });
 
-      var key = container.read<String>('key');
+      final key = container.read<String>('key');
       expect(key, 'ABC123');
     });
 
     test(
         'container items should be able to be built with other container items',
         () {
-      var container = StewardContainer();
+      final container = StewardContainer();
       container.bind<String>('key', (container) {
         return 'ABC';
       });
@@ -29,7 +29,7 @@ void main() {
     });
 
     test('should return null when an unbound binding is made', () {
-      var container = StewardContainer();
+      final container = StewardContainer();
       expect(container.read('key'), null);
     });
   });
@@ -37,18 +37,18 @@ void main() {
   group('clone', () {
     test('Clones should have access to the bindings declare before cloning',
         () {
-      var container = StewardContainer();
+      final container = StewardContainer();
       container.bind('foo', (p0) => 'bar');
 
-      var container2 = container.clone();
+      final container2 = container.clone();
       expect(container2.read('foo'), equals('bar'));
     });
 
     test(
         'updating a binding in a clone should not update the binding for the root',
         () {
-      var container = StewardContainer();
-      var container2 = container.clone();
+      final container = StewardContainer();
+      final container2 = container.clone();
 
       container2.bind('foo', (p0) => 'bar');
       expect(container.read('foo'), equals(null));

--- a/test/forms/forms_test.dart
+++ b/test/forms/forms_test.dart
@@ -4,7 +4,7 @@ import 'package:steward/steward.dart';
 class BadForm extends Form {
   @override
   List<FormError> validator() {
-    var errors = <FormError>[];
+    final errors = <FormError>[];
 
     if (1 != 2) {
       errors.add(FormError('1 != 2'));
@@ -17,7 +17,7 @@ class BadForm extends Form {
 class GoodForm extends Form {
   @override
   List<FormError> validator() {
-    var errors = <FormError>[];
+    final errors = <FormError>[];
 
     if (1 != 1) {
       errors.add(FormError('this should never happen'));
@@ -39,7 +39,7 @@ class FormWithData extends Form {
 
   @override
   List<FormError> validator() {
-    var errors = <FormError>[];
+    final errors = <FormError>[];
 
     if (user.age < 18) {
       errors.add(FormError('user is under 18'));
@@ -52,20 +52,20 @@ class FormWithData extends Form {
 void main() {
   group('Form tests', () {
     test('should handle validation errors', () {
-      var form = BadForm();
+      final form = BadForm();
       expect(form.validate().isNotEmpty, true);
       expect(form.validate()[0].message, '1 != 2');
       expect(form.isValid, false);
     });
 
     test('should handle no validation errors', () {
-      var form = GoodForm();
+      final form = GoodForm();
       expect(form.validate().isEmpty, true);
       expect(form.isValid, true);
     });
 
     test('example with incoming data', () {
-      var form = FormWithData(User(age: 16, name: 'John'));
+      final form = FormWithData(User(age: 16, name: 'John'));
       expect(form.validate().isNotEmpty, true);
       expect(form.validate()[0].message, 'user is under 18');
       expect(form.isValid, false);

--- a/test/router/middleware_routing_test.dart
+++ b/test/router/middleware_routing_test.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:steward/steward.dart';
 import 'package:test/test.dart';
 
-var middlewareLogger = <int>[];
+final middlewareLogger = <int>[];
 
 /// An extremely simple Middleware function that prints the incoming request URI
 Future<Response> Function(Context) FirstMiddleware(

--- a/test/router/middleware_routing_test.dart
+++ b/test/router/middleware_routing_test.dart
@@ -6,27 +6,27 @@ import 'package:test/test.dart';
 var middlewareLogger = <int>[];
 
 /// An extremely simple Middleware function that prints the incoming request URI
-Future<Response> Function(Request) FirstMiddleware(
-    Future<Response> Function(Request) next) {
-  return (Request request) {
+Future<Response> Function(Context) FirstMiddleware(
+    Future<Response> Function(Context) next) {
+  return (Context context) {
     middlewareLogger.add(1);
-    return next(request);
+    return next(context);
   };
 }
 
-Future<Response> Function(Request) SecondMiddleware(
-    Future<Response> Function(Request) next) {
-  return (Request request) {
+Future<Response> Function(Context) SecondMiddleware(
+    Future<Response> Function(Context) next) {
+  return (Context context) {
     middlewareLogger.add(2);
-    return next(request);
+    return next(context);
   };
 }
 
-Future<Response> Function(Request) ThirdMiddleware(
-    Future<Response> Function(Request) next) {
-  return (Request request) {
+Future<Response> Function(Context) ThirdMiddleware(
+    Future<Response> Function(Context) next) {
+  return (Context context) {
     middlewareLogger.add(3);
-    return next(request);
+    return next(context);
   };
 }
 
@@ -35,7 +35,7 @@ void main() {
 
   setUp(() {
     router = Router();
-    router.setDIContainer(CacheContainer());
+    router.setDIContainer(StewardContainer());
     router.serveHTTP();
     middlewareLogger.clear();
   });
@@ -45,7 +45,7 @@ void main() {
   });
 
   test('Route Specific Middlewares execute from left to right order', () async {
-    router.get('/', (Request request) async {
+    router.get('/', (Context context) async {
       return Response.Ok();
     }, middleware: [FirstMiddleware, SecondMiddleware, ThirdMiddleware]);
 

--- a/test/router/router_test.dart
+++ b/test/router/router_test.dart
@@ -20,7 +20,7 @@ void main() {
 
   setUp(() {
     router = Router();
-    router.setDIContainer(CacheContainer());
+    router.setDIContainer(StewardContainer());
     router.serveHTTP();
   });
 
@@ -134,10 +134,10 @@ void main() {
     router.get('/', (_) async {
       return Response.Ok('Success');
     }, middleware: [
-      (Future<Response> Function(Request) next) {
+      (Future<Response> Function(Context) next) {
         called = true;
-        return (Request request) {
-          return next(request);
+        return (Context context) {
+          return next(context);
         };
       }
     ]);
@@ -154,10 +154,10 @@ void main() {
       () async {
     var called = false;
     router.middleware = [
-      (Future<Response> Function(Request) next) {
+      (Future<Response> Function(Context) next) {
         called = true;
-        return (Request request) {
-          return next(request);
+        return (Context context) {
+          return next(context);
         };
       }
     ];

--- a/test/sample.dart
+++ b/test/sample.dart
@@ -1,7 +1,7 @@
 import 'package:steward/router/router.dart';
 
 Future main() async {
-  var router = Router();
+  final router = Router();
   router.get('/hello', (Context context) async {
     return Response.Ok('Hello World!');
   });

--- a/test/sample.dart
+++ b/test/sample.dart
@@ -2,12 +2,12 @@ import 'package:steward/router/router.dart';
 
 Future main() async {
   var router = Router();
-  router.get('/hello', (Request request) async {
+  router.get('/hello', (Context context) async {
     return Response.Ok('Hello World!');
   });
 
-  router.get('/:name', (Request request) async {
-    return Response.Ok(request.pathParams['name']);
+  router.get('/:name', (Context context) async {
+    return Response.Ok(context.request.pathParams['name']);
   });
 
   return router.serveHTTP();

--- a/test/sample_app.dart
+++ b/test/sample_app.dart
@@ -3,18 +3,18 @@ import 'package:steward/router/router.dart';
 
 Future main() async {
   var router = Router();
-  router.get('/hello', (Request request) async {
+  router.get('/hello', (Context context) async {
     return Response.Ok('Hello World!');
   });
 
-  router.get('/config', (Request request) async {
-    print(request.container);
-    print(request.container.make('@config'));
-    return Response.Ok(request.container.make('@config'));
+  router.get('/config', (Context context) async {
+    print(context.request);
+    print(context.read('@config'));
+    return Response.Ok(context.read('@config'));
   });
 
-  router.get('/:name', (Request request) async {
-    return Response.Ok(request.pathParams['name']);
+  router.get('/:name', (Context context) async {
+    return Response.Ok(context.request.pathParams['name']);
   });
 
   var app = App(router: router);


### PR DESCRIPTION
Establish context class, migrate container out of request and into context, replace request in route handlers and middleware with ocontext

BREAKING CHANGE: Handlers now take in a context instead of a request, Container classes broken into smaller more meaningful pieces

fixes #51